### PR TITLE
Add `nodejs` compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,10 +13,6 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': ['@swc-node/jest'],
   },
-  moduleNameMapper: {
-    // Workaround for an error "Cannot find module @emurgo/cardano-serialization-lib-browser"
-    "@emurgo/cardano-serialization-lib-browser": "@emurgo/cardano-serialization-lib-nodejs",
-  },
   coverageThreshold: {
     // global: {
     //   branches: 37,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "author": "fivebinaries.com",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
+  "browser": {
+    "@emurgo/cardano-serialization-lib-nodejs": "@emurgo/cardano-serialization-lib-browser"
+  },
   "files": [
     "lib/**/*.js",
     "lib/**/*.ts"
@@ -24,7 +27,6 @@
     "test:badges": "make-coverage-badge --output-path ./docs/badge-coverage.svg"
   },
   "devDependencies": {
-    "@emurgo/cardano-serialization-lib-nodejs": "11.0.0",
     "@swc-node/jest": "^1.5.2",
     "@types/jest": "^28.1.6",
     "@types/node": "^16.3.2",
@@ -42,7 +44,8 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@emurgo/cardano-serialization-lib-browser": "^11.0.0"
+    "@emurgo/cardano-serialization-lib-browser": "^11.0.0",
+    "@emurgo/cardano-serialization-lib-nodejs": "11.0.0"
   },
   "packageManager": "yarn@3.2.2"
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import * as CardanoWasm from '@emurgo/cardano-serialization-lib-browser';
+import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
 
 export const CertificateType = {
   STAKE_REGISTRATION: 0,

--- a/src/methods/largestFirst.ts
+++ b/src/methods/largestFirst.ts
@@ -1,5 +1,5 @@
 import { ERROR } from '../constants';
-import * as CardanoWasm from '@emurgo/cardano-serialization-lib-browser';
+import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
 import {
   ChangeOutput,
   CoinSelectionParams,

--- a/src/methods/randomImprove.ts
+++ b/src/methods/randomImprove.ts
@@ -1,5 +1,5 @@
 import { ERROR } from '../constants';
-import * as CardanoWasm from '@emurgo/cardano-serialization-lib-browser';
+import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
 import {
   CoinSelectionParams,
   CoinSelectionResult,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,5 @@
-import * as CardanoWasm from '@emurgo/cardano-serialization-lib-browser';
-import { BigNum } from '@emurgo/cardano-serialization-lib-browser';
+import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
+import { BigNum } from '@emurgo/cardano-serialization-lib-nodejs';
 import { CertificateType } from '../constants';
 
 export interface Asset {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,4 @@
-import * as CardanoWasm from '@emurgo/cardano-serialization-lib-browser';
+import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
 import {
   CARDANO_PARAMS,
   CertificateType,

--- a/src/utils/trezor/sign.ts
+++ b/src/utils/trezor/sign.ts
@@ -1,4 +1,4 @@
-import * as CardanoWasm from '@emurgo/cardano-serialization-lib-browser';
+import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
 import {
   CardanoSignedTxWitness,
   CardanoTxWitnessType,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,7 +3,7 @@ jest.setTimeout(30000);
 import {
   BigNum,
   TransactionBody,
-} from '@emurgo/cardano-serialization-lib-browser';
+} from '@emurgo/cardano-serialization-lib-nodejs';
 import { CoinSelectionResult } from '../src/types/types';
 import { multiAssetToArray } from '../src/utils/common';
 


### PR DESCRIPTION
In order to be usable in node version of Trezor Connect as well, `@emurgo/cardano-serialization-lib-nodejs` dependency is used by default instead of `@emurgo/cardano-serialization-lib-browser`, except in browser environment.